### PR TITLE
ci(github): add workflows for auto-release and AUR push

### DIFF
--- a/.github/workflows/aur-push.yml
+++ b/.github/workflows/aur-push.yml
@@ -1,0 +1,64 @@
+name: "Update AUR Package on Release"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-aur:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+
+    steps:
+      - name: Update pacman and install base-devel
+        run: |
+          pacman -Sy --noconfirm --needed base-devel git
+
+      - name: Checkout upstream
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: vars
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        run: |
+          sudo pacman -S --noconfirm --needed \
+            git sed makepkg base-devel
+
+      - name: Prepare SSH key for AUR
+        env:
+          AUR_SSH: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$AUR_SSH" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+
+      - name: Clone AUR repo
+        run: |
+          git clone ssh://aur@aur.archlinux.org/term_planner.git aur
+        working-directory: ${{ github.workspace }}
+
+      - name: Update PKGBUILD in AUR
+        run: |
+          pushd aur
+          sed -i "s/^pkgver=.*/pkgver=${{ steps.vars.outputs.version }}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+          makepkg --printsrcinfo > .SRCINFO
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add PKGBUILD .SRCINFO
+          git commit -m "Update to version ${{ steps.vars.outputs.version }}"
+          git push
+          popd
+
+      - name: Done
+        run: echo "AUR term_planner bumped to ${{ steps.vars.outputs.version }}"
+

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,51 @@
+name: "Auto Release"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: "Bump version & publish"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install cargo-release
+        run: cargo install cargo-release --locked
+
+      - name: Determine bump level from branch name
+        id: bump
+        run: |
+          BRANCH_NAME="${{ github.event.head_commit.message }}"  
+          if [[ "${BRANCH_NAME}" =~ feature/ ]]; then
+            echo "level=minor" >> $GITHUB_OUTPUT
+          elif [[ "${BRANCH_NAME}" =~ fix/ ]]; then
+            echo "level=patch" >> $GITHUB_OUTPUT
+          elif [[ "${BRANCH_NAME}" =~ release/ ]]; then
+            echo "level=major" >> $GITHUB_OUTPUT
+          else
+            echo "level=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump & tag
+        run: |
+          cargo release "${{ steps.bump.outputs.level }}" \
+            --execute \
+            --no-publish
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce two GitHub Actions workflows:
- `auto-release.yml` automates version bumping and GitHub release creation based on commit messages pushed to the main branch. It uses cargo-release to determine the version bump level and tags the release accordingly.
- `aur-push.yml` updates the AUR package upon a new GitHub release. It extracts the version from the release tag, updates the PKGBUILD and .SRCINFO, and pushes changes to the AUR repository using a secret SSH key.

These workflows streamline release management and AUR package maintenance.