### PR TITLE
fix(ci): use release event tag for GitHub Release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.event.release.tag_name }}
+          name: Release ${{ github.event.release.tag_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the GitHub Release step in the workflow to use the tag name from the release event payload instead of the ref name. Also, set the token input directly as required by the action. This ensures correct tag and authentication handling during automated releases.