### PR TITLE
fix(ci): add --yes flag to cargo release for non-interactive run

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -43,4 +43,5 @@ jobs:
           cargo release "${{ steps.bump.outputs.level }}" \
             --execute \
             --no-publish \
-            --push
+            --push \
+            --yes


### PR DESCRIPTION
The --yes flag is added to the cargo release command in the CI workflow to ensure non-interactive execution. This prevents prompts during the release process, making the workflow fully automated and suitable for CI environments.