### PR TITLE
fix(ci): correct version bump and cleanup workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -20,14 +20,12 @@ jobs:
           override: true
 
       - name: Install cargo-edit
-        run: |
-          cargo install cargo-edit --locked
+        run: cargo install cargo-edit --locked
 
-      - name: Determine bump level from branch name
+      - name: Determine bump level
         id: bump
         run: |
           LEVEL="patch"
-
           BRANCH="${GITHUB_REF##*/}"
           if [[ "$BRANCH" =~ ^feature/ ]]; then
             LEVEL="minor"
@@ -36,13 +34,12 @@ jobs:
           elif [[ "$BRANCH" =~ ^breaking/ ]]; then
             LEVEL="major"
           fi
-
           echo "level=$LEVEL" >> $GITHUB_OUTPUT
 
       - name: Bump Cargo.toml version
         id: bumpver
         run: |
-          OLD=$(grep '^version ' Cargo.toml | cut -d\" -f2)
+          OLD=$(grep '^version =' Cargo.toml | cut -d\" -f2)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$OLD"
 
           case "${{ steps.bump.outputs.level }}" in
@@ -52,6 +49,7 @@ jobs:
           esac
 
           NEW="$MAJOR.$MINOR.$PATCH"
+
           echo "old=$OLD" >> $GITHUB_OUTPUT
           echo "new=$NEW" >> $GITHUB_OUTPUT
 
@@ -70,4 +68,3 @@ jobs:
           git commit -m "chore: bump version ${{ steps.bumpver.outputs.new }}"
           git tag -a "v${{ steps.bumpver.outputs.new }}" -m "Release v${{ steps.bumpver.outputs.new }}"
           git push origin main --follow-tags
-


### PR DESCRIPTION
- Fix grep pattern for extracting version from Cargo.toml to match 'version ='
- Simplify cargo-edit installation step
- Remove unnecessary blank lines and clarify bump level step
- Update step name to 'Determine bump level'
- Minor formatting improvements for consistency