### PR TITLE
chore(ci): add permissions for release workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: write
+
 name: CI & Tag Release
 
 on:


### PR DESCRIPTION
Added 'contents: write' permissions to the GitHub Actions release workflow. This is required for workflows that create or push tags and releases.