### PR TITLE
ci: update Cargo.lock before committing release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -54,6 +54,12 @@ jobs:
           fi
           set -e
 
+      - name: Update Cargo.lock
+        steps:
+          - uses: actions-rs/cargo@v1
+            with:
+              command: update
+
       - name: Commit bump and push tag
         if: steps.bumpver.outputs.new != steps.bumpver.outputs.old
         env:


### PR DESCRIPTION
Add a step to update Cargo.lock in the CI release workflow. This ensures the lockfile is up-to-date before committing version bumps and pushing tags, maintaining consistency between dependencies and the codebase.