### PR TITLE
fix(task): correct is_empty logic in TaskVec

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -70,7 +70,7 @@ impl TaskVec {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.len() > 0
+        self.tasks.is_empty()
     }
 
     pub fn get_as_text(&self, idx: usize) -> String {


### PR DESCRIPTION
Previously, TaskVec::is_empty returned true when the length was greater than zero, which is incorrect. Now it properly checks if the tasks vector is empty using self.tasks.is_empty(). This fixes potential logic errors when checking for an empty task list.